### PR TITLE
Update install_miniconda.sh

### DIFF
--- a/devtools/travis-ci/install_miniconda.sh
+++ b/devtools/travis-ci/install_miniconda.sh
@@ -11,5 +11,6 @@ rm -f $MINICONDA
 
 export PATH=$HOME/miniconda3/bin:$PATH
 
+conda install python=$CONDA_PY
 conda update -yq conda
 conda install -yq conda-build jinja2

--- a/devtools/travis-ci/install_miniconda.sh
+++ b/devtools/travis-ci/install_miniconda.sh
@@ -11,6 +11,6 @@ rm -f $MINICONDA
 
 export PATH=$HOME/miniconda3/bin:$PATH
 
-conda install python=$CONDA_PY
+conda install -yq python=$CONDA_PY
 conda update -yq conda
 conda install -yq conda-build jinja2


### PR DESCRIPTION
Account for Python 3.6 being added to the latest version, since coveralls isn't py3.6 compatible yet.

cc @mpharrigan: is there a better way to do this?