### PR TITLE
Implied timescales plot

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ v1.0.1 (Development)
 New Features
 ~~~~~~~~~~~~
 
-- Added a new function `plot_implied_timescales`` that accepts a list of msm objects
+- Added a new function ``plot_implied_timescales`` that accepts a list of msm objects
   calculated at different lag times. Returns an implied timescales plot (#90).
 
 - ``plot_free_energy`` now accepts a ``return_data`` flag that will return 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ v1.0.1 (Development)
 New Features
 ~~~~~~~~~~~~
 
+- Added a new function `plot_implied_timescales`` that accepts a list of msm objects
+  calculated at different lag times. Returns an implied timescales plot (#90).
+
 - ``plot_free_energy`` now accepts a ``return_data`` flag that will return 
   the data used for the free energy plot(#78).
 

--- a/examples/plot_implied_timescales.py
+++ b/examples/plot_implied_timescales.py
@@ -1,0 +1,44 @@
+"""
+Implied Timescales Plot
+===============
+"""
+from msmbuilder.example_datasets import FsPeptide
+from msmbuilder.featurizer import DihedralFeaturizer
+from msmbuilder.decomposition import tICA
+from msmbuilder.cluster import MiniBatchKMeans
+from msmbuilder.msm import MarkovStateModel
+
+import numpy as np
+
+import msmexplorer as msme
+
+rs = np.random.RandomState(42)
+
+# Load Fs Peptide Data
+trajs = FsPeptide().get().trajectories
+
+# Extract Backbone Dihedrals
+featurizer = DihedralFeaturizer(types=['phi', 'psi'])
+diheds = featurizer.fit_transform(trajs)
+
+# Perform Dimensionality Reduction
+tica_model = tICA(lag_time=2, n_components=2)
+tica_trajs = tica_model.fit_transform(diheds)
+
+# Perform Clustering
+clusterer = MiniBatchKMeans(n_clusters=100, random_state=rs)
+clustered_trajs = clusterer.fit_transform(tica_trajs)
+
+lag_times = [1, 10, 50, 100, 200, 250, 500]
+msm_objs = []
+for lag in lag_times:
+    # Construct MSM
+    msm = MarkovStateModel(lag_time=lag, n_timescales=5)
+    msm.fit(clustered_trajs)
+    msm_objs.append(msm)
+
+# Plot Timescales
+colors = ['pomegranate', 'beryl', 'tarragon', 'rawdenim', 'carbon']
+msme.plot_implied_timescales(msm_objs, color_palette=colors,
+                             xlabel='Lag time (frames)',
+                             ylabel='Implied Timescales ($ns$)')

--- a/examples/plot_implied_timescales.py
+++ b/examples/plot_implied_timescales.py
@@ -29,7 +29,7 @@ tica_trajs = tica_model.fit_transform(diheds)
 clusterer = MiniBatchKMeans(n_clusters=100, random_state=rs)
 clustered_trajs = clusterer.fit_transform(tica_trajs)
 
-lag_times = [1, 10, 50, 100, 200, 250, 500]
+lag_times = [1, 50, 100, 250, 500, 1000, 5000]
 msm_objs = []
 for lag in lag_times:
     # Construct MSM

--- a/msmexplorer/plots/msm.py
+++ b/msmexplorer/plots/msm.py
@@ -249,12 +249,6 @@ def plot_implied_timescales(msm_list, n_timescales=None, show_error=True,
             pp.fill_between(x=lag_times,
                             y1=[ts - err for ts, err in zip(timescales, errors)],
                             y2=[ts + err for ts, err in zip(timescales, errors)],
-                            color=color)
+                            color=color, alpha=0.5)
 
-    if xlabel:
-        ax.xaxis.set_label_text(xlabel)
-    if ylabel:
-        ax.yaxis.set_label_text(ylabel)
-    ax.set_yscale('log')
-    ax.set_ylim([ymin, ymax])
     return ax

--- a/msmexplorer/plots/msm.py
+++ b/msmexplorer/plots/msm.py
@@ -196,6 +196,33 @@ def plot_timescales(msm, n_timescales=None, error=None, sigma=2,
 @msme_colors
 def plot_implied_timescales(msm_list, n_timescales=None, show_error=True,
                             color_palette=None, xlabel=None, ylabel=None, ax=None):
+    """
+    Plot implied timescales as a function of the MSM lag time
+
+    Parameters
+    ----------
+    msm_list: list of msmbuilder.msm.MarkovStateModel objects
+        A list of msm objects, calculated at different lag times
+    n_timescales: int, optional
+        Number of timescales to display. If None, all will be displayed.
+    show_error: bool, optional
+        Wether to display the uncertainty estimation of the timescales as a
+        shadowed region
+    color_palette: list or dict, optional
+        Color palette to apply
+    xlabel : str, optional
+        x-axis label
+    ylabel : str, optional
+        y-axis label
+    ax : matplotlib axis, optional (default: None)
+        Axis to plot on, otherwise uses current axis.
+
+    Returns
+    -------
+    ax : matplotlib axis
+        matplotlib figure axis
+
+    """
     if n_timescales is None:
         n_timescales = len(msm_list[0].timescales_)
     elif n_timescales > len(msm_list[0].timescales_):

--- a/msmexplorer/plots/msm.py
+++ b/msmexplorer/plots/msm.py
@@ -223,22 +223,39 @@ def plot_implied_timescales(msm_list, n_timescales=None, show_error=True,
         matplotlib figure axis
 
     """
+    # Determine how many timescales to show in plot
     if n_timescales is None:
         n_timescales = len(msm_list[0].timescales_)
     elif n_timescales > len(msm_list[0].timescales_):
         n_timescales = len(msm_list[0].timescales_)
 
-    lag_times = [msm.lag_time for msm in msm_list]
-
-    long_ts = [msm.timescales_[0] for msm in msm_list]
-    short_ts = [msm.timescales_[-1] for msm in msm_list]
-    ymin = 10 ** np.floor(np.log10(np.nanmin(short_ts)))
-    ymax = 10 ** np.ceil(np.log10(np.nanmax(long_ts)))
-
+    # Create axis object
     if not ax:
         _, ax = pp.subplots(1, 1)
     if not color_palette:
         color_palette = list(msme_rgb.values())
+
+    # y axis setup
+    long_ts = [msm.timescales_[0] for msm in msm_list]
+    short_ts = [msm.timescales_[-1] for msm in msm_list]
+    ymin = 10 ** np.floor(np.log10(np.nanmin(short_ts)))
+    ymax = 10 ** np.ceil(np.log10(np.nanmax(long_ts)))
+    ax.set_yscale('log')
+    ax.set_ylim([ymin, ymax])
+    if ylabel:
+        ax.yaxis.set_label_text(ylabel)
+
+    # x axis setup
+    lag_times = [msm.lag_time for msm in msm_list]
+    if (max(lag_times) / min(lag_times)) >= 1e3:
+        xmin = 10 ** np.floor(np.log10(np.nanmin(lag_times)))
+        xmax = 10 ** np.ceil(np.log10(np.nanmax(lag_times)))
+        ax.set_xscale('log')
+    else:
+        xmin, xmax = min(lag_times), max(lag_times)
+    ax.set_xlim([xmin, xmax])
+    if xlabel:
+        ax.xaxis.set_label_text(xlabel)
 
     for ts in range(n_timescales):
         timescales = [msm.timescales_[ts] for msm in msm_list]

--- a/msmexplorer/plots/msm.py
+++ b/msmexplorer/plots/msm.py
@@ -250,7 +250,7 @@ def plot_implied_timescales(msm_list, n_timescales=None, show_error=True,
                             y1=[ts - err for ts, err in zip(timescales, errors)],
                             y2=[ts + err for ts, err in zip(timescales, errors)],
                             color=color)
-    ax.set_yscale('log')
+
     if xlabel:
         ax.xaxis.set_label_text(xlabel)
     if ylabel:

--- a/msmexplorer/tests/test_msm_plot.py
+++ b/msmexplorer/tests/test_msm_plot.py
@@ -43,7 +43,7 @@ def test_plot_implied_timescales():
     for lag in lag_times:
         # Construct MSM
         msm = MarkovStateModel(lag_time=lag, n_timescales=5)
-        msm.fit(clustered_trajs)
+        msm.fit(data)
         msm_objs.append(msm)
     ax = plot_implied_timescales(msm_objs)
     assert isinstance(ax, SubplotBase)

--- a/msmexplorer/tests/test_msm_plot.py
+++ b/msmexplorer/tests/test_msm_plot.py
@@ -3,7 +3,7 @@ from msmbuilder.msm import MarkovStateModel, BayesianMarkovStateModel
 from matplotlib.axes import SubplotBase
 from seaborn.apionly import JointGrid
 
-from ..plots import plot_pop_resids, plot_msm_network, plot_timescales
+from ..plots import plot_pop_resids, plot_msm_network, plot_timescales, plot_implied_timescales
 
 rs = np.random.RandomState(42)
 data = rs.randint(low=0, high=10, size=100000)
@@ -34,4 +34,16 @@ def test_plot_timescales_msm():
 def test_plot_timescales_bmsm():
     ax = plot_timescales(bmsm)
 
+    assert isinstance(ax, SubplotBase)
+
+
+def test_plot_implied_timescales():
+    lag_times = [1, 10, 50, 100, 200, 250, 500]
+    msm_objs = []
+    for lag in lag_times:
+        # Construct MSM
+        msm = MarkovStateModel(lag_time=lag, n_timescales=5)
+        msm.fit(clustered_trajs)
+        msm_objs.append(msm)
+    ax = plot_implied_timescales(msm_objs)
     assert isinstance(ax, SubplotBase)

--- a/msmexplorer/tests/test_msm_plot.py
+++ b/msmexplorer/tests/test_msm_plot.py
@@ -38,7 +38,7 @@ def test_plot_timescales_bmsm():
 
 
 def test_plot_implied_timescales():
-    lag_times = [1, 10, 50, 100, 200, 250, 500]
+    lag_times = [1, 50, 100, 250, 500, 1000, 5000]
     msm_objs = []
     for lag in lag_times:
         # Construct MSM


### PR DESCRIPTION
## Proposed Feature / Bug-Fix

Adding an implied timescales plot, as I suggested in [#89](https://github.com/msmexplorer/msmexplorer/issues/89)



## Example Figure
Plot a list of msm objects like this:
```python
plot_implied_timescales(msm_objs, color_palette=colors,
                        xlabel='Lag time (frames)',
                        ylabel='Implied Timescales ($ns$)')
```
![its-ex](https://cloud.githubusercontent.com/assets/10696140/25275207/0146771e-268c-11e7-8299-9d5a8fdd22c3.png)


## PR Check-list

- [x] Example added
- [x] Tests added
- [x] Docs added
  - Isn't it updated from the docstring of the function?
- [x] Changelog updated
